### PR TITLE
Add RegularRecord to track regular schedule change and fix service ac…

### DIFF
--- a/src/main/java/springbeam/susukgwan/schedule/RegularRecord.java
+++ b/src/main/java/springbeam/susukgwan/schedule/RegularRecord.java
@@ -1,0 +1,35 @@
+package springbeam.susukgwan.schedule;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import springbeam.susukgwan.tutoring.Tutoring;
+
+import java.time.LocalDateTime;
+
+// 조회(select)가 많이 일어나고 insert는 적고 delete는 거의 없고 update 또한 적으므로 인덱싱 하면 좋음.
+// but, JPA로 자동 테이블 생성 시 기본키, 참조키는 자동 인덱싱되므로 불필요한 코드일 수 있음. 참고용 코드임.
+@Entity
+@Table(name = "regular_record", indexes = @Index(name = "idx__tutoring_id", columnList = "tutoring_id"))
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@SuperBuilder
+public class RegularRecord {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tutoring_id")
+    private Tutoring tutoring;
+
+    private LocalDateTime appliedUntil;
+
+    private String dayTimeString;
+
+}

--- a/src/main/java/springbeam/susukgwan/schedule/RegularRecordRepository.java
+++ b/src/main/java/springbeam/susukgwan/schedule/RegularRecordRepository.java
@@ -1,0 +1,13 @@
+package springbeam.susukgwan.schedule;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import springbeam.susukgwan.tutoring.Tutoring;
+
+import java.util.List;
+
+@Repository
+public interface RegularRecordRepository extends JpaRepository<RegularRecord, Long> {
+    // List<RegularRecord> findAllByTutoring(Tutoring tutoring);
+    List<RegularRecord> findAllByTutoringOrderByAppliedUntilAsc(Tutoring tutoring);
+}

--- a/src/main/java/springbeam/susukgwan/tutoring/Tutoring.java
+++ b/src/main/java/springbeam/susukgwan/tutoring/Tutoring.java
@@ -6,6 +6,7 @@ import lombok.experimental.SuperBuilder;
 import springbeam.susukgwan.note.Note;
 import springbeam.susukgwan.schedule.Cancellation;
 import springbeam.susukgwan.schedule.Irregular;
+import springbeam.susukgwan.schedule.RegularRecord;
 import springbeam.susukgwan.schedule.Time;
 import springbeam.susukgwan.subject.Subject;
 import springbeam.susukgwan.tutoring.color.Color;
@@ -39,6 +40,9 @@ public class Tutoring {
 
     @OneToMany(mappedBy = "tutoring", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Cancellation> cancellations = new ArrayList<>(); // 튜터링 삭제 시 관련 정규취소가 삭제됨.
+
+    @OneToMany(mappedBy = "tutoring", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<RegularRecord> regularRecords = new ArrayList<>(); //
 
     @OneToMany(mappedBy = "tutoring", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Irregular> irregulars = new ArrayList<>(); // 튜터링 삭제 시 관련 비정규일정이 삭제됨.

--- a/src/main/java/springbeam/susukgwan/tutoring/TutoringService.java
+++ b/src/main/java/springbeam/susukgwan/tutoring/TutoringService.java
@@ -72,8 +72,12 @@ public class TutoringService {
         Tutoring newTutoring = Tutoring.builder().tutorId(tutorId).startDate(startDate)
                         .subject(subject) // 과목 매핑
                         .build();
-        tutoringRepository.save(newTutoring);
-        return scheduleService.registerRegularSchedule(newTutoring, registerTutoringDTO.getDayTime());
+        ResponseEntity response = scheduleService.registerRegularSchedule(newTutoring, registerTutoringDTO.getDayTime());
+        // 일정 등록이 성공할 경우에만 수업을 저장하도록 한다.
+        if (response.getStatusCode() == HttpStatus.OK) {
+            tutoringRepository.save(newTutoring);
+        }
+        return response;
     }
 
     public ResponseEntity<?> updateTutoring(Long tutoringId, UpdateTutoringDTO updateTutoringDTO) {
@@ -325,9 +329,8 @@ public class TutoringService {
             tutoringDetailDTO.setParentName(userRepository.findById(tutoring.getParentId()).get().getName());
         }
         // get schedule list and include it to DTO
-        // TODO 아래 타입체크? 혹은 추가 함수?
-        ResponseEntity<?> scheduleListYearMonth = scheduleService.getScheduleListYearMonth(tutoringId, year, month);
-        List<ScheduleInfoResponseDTO> scheduleList = (List<ScheduleInfoResponseDTO>) scheduleListYearMonth.getBody();
+        List<ScheduleInfoResponseDTO> scheduleList = scheduleService.getOnlyScheduleListYearMonth(tutoring, year, month);
+
         tutoringDetailDTO.setScheduleList(scheduleList);
 
         // get review list and include it to DTO


### PR DESCRIPTION
…cordingly

changeRegular 에서 이전 정규일정 저장 ok
newIrregularSchedule 과거의 정규일정과 겹치면 비정규 등록 못하도록 하기 ok
cancelSchedule 과거의 정규일정도 취소(삭제) 가능하게 하기 ok
replaceSchedule 과거의 정규일정과 겹치면 변경 못하게 하기 ok, 이전 정규일정에 대한 취소일 경우를 확인하기 ok
위의 서비스에서 미래의 일정 변경일 때에만 알림이 가도록 적용(변경은 하나라도 미래에 걸치면 알림) ok
현재일정 조회 3가지 서비스! -> RegularRecord 조회하도록 처리하기! ok